### PR TITLE
fix: path to rz/sz command

### DIFF
--- a/iterm2-recv-zmodem.sh
+++ b/iterm2-recv-zmodem.sh
@@ -20,7 +20,7 @@ if [[ $FILE = "" ]]; then
 	echo \# Cancelled transfer
 else
 	cd "$FILE"
-	/usr/local/bin/rz --rename --escape --binary --bufsize 4096 
+	$(which rz) --rename --escape --binary --bufsize 4096 
 	sleep 1
 	echo
 	echo

--- a/iterm2-send-zmodem.sh
+++ b/iterm2-send-zmodem.sh
@@ -18,7 +18,7 @@ if [[ $FILE = "" ]]; then
 	echo
 	echo \# Cancelled transfer
 else
-	/usr/local/bin/sz "$FILE" --escape --binary --bufsize 4096
+	$(which sz) "$FILE" --escape --binary --bufsize 4096
 	sleep 1
 	echo
 	echo \# Received "$FILE"


### PR DESCRIPTION
When I try to config lrzsz for iterm2 following your excellent repository instructions, I meet up with some error. 
My machine is M1 Mac 2021 and I use `homebrew` to install lrzsz. As you can see from image below,  the default installation directory is no longer `/usr/local/bin`, which is exactly what causes the error I meet.
<img width="284" alt="image" src="https://user-images.githubusercontent.com/44457621/193444889-04c8bce1-58e6-47e9-8240-0a0ad95432a9.png">
I think we can use the `which` command  instead of hard-coded to fix this problem.